### PR TITLE
Add Send Test and Send buttons to the email editing page

### DIFF
--- a/app/bundles/EmailBundle/Views/Email/form.html.php
+++ b/app/bundles/EmailBundle/Views/Email/form.html.php
@@ -29,6 +29,34 @@ $emailType = $form['emailType']->vars['data'];
 if (!isset($attachmentSize)) {
     $attachmentSize = 0;
 }
+
+$customButtons = array();
+if ($emailType == 'list') {
+    $customButtons[] = array(
+        'attr' => array(
+            'data-toggle' => 'ajax',
+            'href'        => $view['router']->generate('mautic_email_action', array('objectAction' => 'send', 'objectId'
+ => $email->getId())),
+        ),
+        'iconClass' => 'fa fa-send-o',
+        'btnText'   => 'mautic.email.send'
+    );
+}
+$customButtons[] = array(
+    'attr' => array(
+        'data-toggle' => 'ajax',
+        'href'        => $view['router']->generate('mautic_email_action', array('objectAction' => 'example', 'objectId'
+=> $email->getId())),
+    ),
+    'iconClass' => 'fa fa-send',
+    'btnText'   => 'mautic.email.send.example'
+);
+$view['slots']->set('actions', $view->render('MauticCoreBundle:Helper:page_actions.html.php', array(
+    'item'       => $email,
+    'routeBase'  => 'email',
+    'customButtons' => $customButtons
+)));
+
 ?>
 
 


### PR DESCRIPTION
This is kind of the beginning of the change, I'm not 100% happy with it.  Outstanding issues:
- Doesn't save before sending the message, or even warn you that it won't save
- After "Send Test" you land back on the "view" page, not the "edit" page

Any hints on how to resolve these would be much appreciated, I'm new to Symfony and this whole forms framework you are using definitely has a bit of a learning curve.
